### PR TITLE
Use CC-esque noncommercial definition with PolyForm Personal Uses

### DIFF
--- a/terms.md
+++ b/terms.md
@@ -10,7 +10,13 @@ To receive this license, you have to agree to its rules.  Those rules are both o
 
 ### Noncommercial
 
-You may not use the software to make money or for work, except for [Free Trials](#free-trials) and [Kids' Projects](#kids-projects).
+You may not use the software in business or paid work, except for [Free Trials](#free-trials) and [Kids' Projects](#kids-projects).
+
+<!-- Adapted from PolyForm Noncommercial 1.0.0 -->
+
+### Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, does not count as use in business.
 
 ### Free Trials
 

--- a/terms.md
+++ b/terms.md
@@ -16,7 +16,7 @@ You may not use the software in business or paid work, except for [Free Trials](
 
 ### Personal Uses
 
-Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, does not count as use in business.
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, does not count as use in business or paid work.
 
 ### Free Trials
 


### PR DESCRIPTION
This alternative to #2 uses a slightly different approach:
- track Creative Commons' [4.0 approach to defining "commercial"](https://creativecommons.org/licenses/by-nc/4.0/legalcode), but simplify the language
- add in the [Personal Uses section from PolyForm Noncommercial 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0/#personal-uses)

This PR does _not_ include a PolyForm-style [Noncommercial Organizations](https://polyformproject.org/licenses/noncommercial/1.0.0/#noncommercial-organizations) section, which would cover, say, work at universities, even under for-profit grant.

The Creative Commons language for commercial use is a little wordier:
> in any manner that is primarily intended for or directed toward commercial advantage or private monetary compensation

However, some research that CC themselves did on public perception of the terms seemed to confirm that few really pay attention to these nuances. To my eye, the key is that a use falls out of bounds if it's business-related _or_ is being compensated. So a for-profit contractor or consultant working for a nonprofit, arguably noncommercial organization for pay still falls out of bounds.

I've tried to capture both prongs of that essence in shorter, plainer terms here.

@orlandohill, might you spare a couple minutes to share first thoughts?